### PR TITLE
Put rxjs in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/alex-okrushko/backoff-rxjs/issues"
   },
   "homepage": "https://github.com/alex-okrushko/backoff-rxjs#readme",
-  "dependencies": {
+  "peerDependencies": {
     "rxjs": "^6.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It's better to have rxjs as one of peerDependencies.
Considering the final bundle size, it's not good to have separate rxjs installations in one environment.
This can easily happen when using other rxjs-related libraries or when using rxjs in the main source code.