### PR TITLE
Add option to reset interval on success

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+build

--- a/spec/mocha.opts
+++ b/spec/mocha.opts
@@ -1,2 +1,2 @@
---compilers ts:ts-node/register
+--require ts-node/register
 spec/**/*-spec.ts

--- a/spec/retryBackoff-spec.ts
+++ b/spec/retryBackoff-spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
-import { retryBackoff } from '../src/index';
-import { of, Observable, Observer, throwError, Subject } from 'rxjs';
-import { map, mergeMap, concat, multicast, refCount } from 'rxjs/operators';
+import { Observable, Observer, of, Subject, throwError } from 'rxjs';
+import { concat, map, mergeMap, multicast, refCount } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
+import { retryBackoff } from '../src/index';
 
 describe('retryBackoff operator', () => {
   let testScheduler: TestScheduler;
@@ -253,7 +253,7 @@ describe('retryBackoff operator', () => {
     of(1, 2, 3)
       .pipe(
         concat(throwError('bad!')),
-        multicast(() => new Subject()),
+        multicast(() => new Subject<number>()),
         refCount(),
         retryBackoff({ initialInterval: 1, maxRetries: 4 })
       )

--- a/src/operators/retryBackoff.ts
+++ b/src/operators/retryBackoff.ts
@@ -1,4 +1,4 @@
-import { iif, Observable, throwError, timer } from 'rxjs';
+import { defer, iif, Observable, throwError, timer } from 'rxjs';
 import { concatMap, retryWhen, tap } from 'rxjs/operators';
 import { exponentialBackoffDelay, getDelay } from '../utils';
 
@@ -37,7 +37,7 @@ export function retryBackoff(
     resetOnSuccess = false,
     backoffDelay = exponentialBackoffDelay
   } = typeof config === 'number' ? { initialInterval: config } : config;
-  return <T>(source: Observable<T>) => {
+  return <T>(source: Observable<T>) => defer(() => {
     let index = 0;
     return source.pipe(
       retryWhen<T>(errors =>
@@ -58,5 +58,5 @@ export function retryBackoff(
         }
       })
     );
-  }
+  })
 }

--- a/src/operators/retryBackoff.ts
+++ b/src/operators/retryBackoff.ts
@@ -52,7 +52,7 @@ export function retryBackoff(
           })
         )
       ),
-      tap((_: T) => {
+      tap(() => {
         if (resetOnSuccess) {
           index = 0;
         }


### PR DESCRIPTION
This pull-request adds an option to reset the state of the `retryBackoff` operator on successful emissions on the source observable. 

When this option is enabled (it's `off` by default to maintain backwards compatibility) both the delay interval and the attempt counter gets reset when the source observable emits a value.

### Use cases

Some of the arguments and motivation for this option were nicely laid out in https://github.com/ReactiveX/rxjs/issues/1413. A similar option was recently added to the [retry](https://rxjs-dev.firebaseapp.com/api/operators/retry) operator (https://github.com/ReactiveX/rxjs/pull/5280).

Quoting @benlesh from the linked issue:
> Often with retryWhen there is a desire to reset some "state" of your retries when the stream your retrying starts receiving values successfully again. For example, in a network retry scenario where you want to exponentially step back from the first failure. Once you get a value over that network observable, you want to reset your exponential step back to the first level again, because things are going well now.


### Code review notes

The first four commits are not related to this pull-request and I can submit them separately if needed. They are related to some small nuisances I encountered when running the tests locally.