### PR TITLE
Includes support for rxjs 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/alex-okrushko/backoff-rxjs#readme",
   "peerDependencies": {
-    "rxjs": "^6.5.5"
+    "rxjs": "^6.5.5 || ^7.0.0-rc"
   },
   "devDependencies": {
     "@types/jest": "^25.2.2",


### PR DESCRIPTION
This updates the peerdependency of rxjs to include version 7.

rxjs 7 has no breaking changes that relates to backoff-rxjs, but provides benifts, such as a smaller bundle size.

btw fixes #36 